### PR TITLE
Jurors: get first 1000 jurors in query

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -23,7 +23,7 @@ export function useAnJurors() {
         GQL_ENDPOINT,
         `
           {
-            jurors {
+            jurors(first: 1000) {
               activeBalance
             }
           }


### PR DESCRIPTION
The Graph only allows querying the first 1000 items (defaults to 100 and errors if above 100). Here's hoping that we need to implement pagination soon