### PR TITLE
Sentry: pass environment and release as params

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -7,6 +7,8 @@ const envVars = {
     process.env.SUBSCRIPTIONS_URL,
     'https://court-backend.eth.aragon.network/subscriptions',
   ],
+  BUILD: [process.env.BUILD, ''],
+  NODE_ENV: [process.env.NODE_ENV, 'development'],
 }
 
 export default function environment(name) {

--- a/src/index.js
+++ b/src/index.js
@@ -11,11 +11,11 @@ import App from './App'
 export default App
 
 if (env('SENTRY_DSN')) {
-  if (typeof window !== 'undefined') {
-    window.SENTRY_RELEASE = process.env.BUILD
-    window.SENTRY_ENVIRONMENT = process.env.NODE_ENV
-  }
-  Sentry.init({ dsn: env('SENTRY_DSN') })
+  Sentry.init({
+    dsn: env('SENTRY_DSN'),
+    environment: env('NODE_ENV'),
+    release: 'anj.aragon.org@' + env('BUILD'),
+  })
 }
 
 // Render your app


### PR DESCRIPTION
It seems the release and environment weren’t working with WINDOW.SENTRY_ vars.