### PR TITLE
Conversion: increase timeout to 120min, decrease max slippage to 5%

### DIFF
--- a/src/web3-contracts.js
+++ b/src/web3-contracts.js
@@ -273,7 +273,7 @@ export function useConvertTokenToAnj(selectedToken) {
       // now + 60s * 120min
       const twoHourExpiry = Math.floor(Date.now() / 1000) + 60 * 120
       const underestimatedAnt = estimatedAnt
-        .mul(90)
+        .mul(95)
         .div(100)
         .toString()
 
@@ -320,7 +320,7 @@ export function useConvertTokenToAnj(selectedToken) {
           )
         )
       )
-        .mul(90)
+        .mul(95)
         .div(100)
       return await wrapperContract.contributeExternalToken(
         tokenAddress,

--- a/src/web3-contracts.js
+++ b/src/web3-contracts.js
@@ -270,7 +270,8 @@ export function useConvertTokenToAnj(selectedToken) {
         throw new Error('Could not get the token and wrapper contract.')
       }
 
-      const tenMinuteExpiry = Math.floor(Date.now() / 1000) + 60 * 10
+      // now + 60s * 120min
+      const twoHourExpiry = Math.floor(Date.now() / 1000) + 60 * 120
       const underestimatedAnt = estimatedAnt
         .mul(90)
         .div(100)
@@ -280,7 +281,7 @@ export function useConvertTokenToAnj(selectedToken) {
       if (selectedToken === 'ETH') {
         return await wrapperContract.contributeEth(
           underestimatedAnt,
-          tenMinuteExpiry,
+          twoHourExpiry,
           true,
           {
             gasLimit: 1000000,
@@ -326,7 +327,7 @@ export function useConvertTokenToAnj(selectedToken) {
         amount,
         underestimatedAnt,
         estimatedEth,
-        tenMinuteExpiry,
+        twoHourExpiry,
         true,
         {
           gasLimit: 1000000,


### PR DESCRIPTION
We're seeing quite a few transactions to the wrapper fail because of the short deadline we set.

This also increases the min price to be 95% of what's was expected, so we should be generally safe.

I suspect the uniswap market spot price isn't moving significantly (or at least, downwards) but the gas market is volatile and taking longer than expected for some users to get their transactions mined.