### PR TITLE
Remove hardcoded gas limit outside of separate approve and contribute transactions

### DIFF
--- a/src/web3-contracts.js
+++ b/src/web3-contracts.js
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
-import { ethers, Contract as EthersContract } from 'ethers'
+import { Contract as EthersContract } from 'ethers'
 import { getKnownContract } from './known-contracts'
 import tokenBalanceOfAbi from './token-balanceof.json'
 import { useWeb3Connect } from './web3-connect'
@@ -294,7 +294,6 @@ export function useConvertTokenToAnj(selectedToken) {
           twoHourExpiry,
           true,
           {
-            gasLimit: 650000,
             value: amount,
           }
         )
@@ -323,9 +322,7 @@ export function useConvertTokenToAnj(selectedToken) {
 
         const data = `0x${encodedActivation}${encodedMinTokens}${encodedMinEth}${encodedDeadline}`
 
-        return tokenContract.approveAndCall(wrapperAddress, amount, data, {
-          gasLimit: 1000000,
-        })
+        return tokenContract.approveAndCall(wrapperAddress, amount, data)
       }
 
       // else, we may need two transactions:
@@ -351,7 +348,7 @@ export function useConvertTokenToAnj(selectedToken) {
         twoHourExpiry,
         activate,
         {
-          gasLimit: 650000,
+          gasLimit: 850000,
         }
       )
     },


### PR DESCRIPTION
Some transactions have been failing due to out of gas, for example: https://dashboard.tenderly.dev/tx/main/0x94446b2bd503602136513994ecf2c158b7898ec04f3cf08e9c5427f99c48e81a/gas-usage.

Most transactions should not need hardcoded gas; we only specify gas when immediately sending two transaction (e.g. approve and then contribute) to "trick" some web3 wallets into not showing a warning.