### PR TITLE
Add back hardcoded gas limits

### DIFF
--- a/src/web3-contracts.js
+++ b/src/web3-contracts.js
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
-import { Contract as EthersContract } from 'ethers'
+import { ethers, Contract as EthersContract } from 'ethers'
 import { getKnownContract } from './known-contracts'
 import tokenBalanceOfAbi from './token-balanceof.json'
 import { useWeb3Connect } from './web3-connect'
@@ -294,6 +294,7 @@ export function useConvertTokenToAnj(selectedToken) {
           twoHourExpiry,
           true,
           {
+            gasLimit: 650000,
             value: amount,
           }
         )
@@ -322,7 +323,9 @@ export function useConvertTokenToAnj(selectedToken) {
 
         const data = `0x${encodedActivation}${encodedMinTokens}${encodedMinEth}${encodedDeadline}`
 
-        return tokenContract.approveAndCall(wrapperAddress, amount, data)
+        return tokenContract.approveAndCall(wrapperAddress, amount, data, {
+          gasLimit: 1000000,
+        })
       }
 
       // else, we may need two transactions:
@@ -348,7 +351,7 @@ export function useConvertTokenToAnj(selectedToken) {
         twoHourExpiry,
         activate,
         {
-          gasLimit: 850000,
+          gasLimit: 650000,
         }
       )
     },

--- a/src/web3-contracts.js
+++ b/src/web3-contracts.js
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
-import { ethers, Contract as EthersContract } from 'ethers'
+import { Contract as EthersContract } from 'ethers'
 import { getKnownContract } from './known-contracts'
 import tokenBalanceOfAbi from './token-balanceof.json'
 import { useWeb3Connect } from './web3-connect'
@@ -294,7 +294,7 @@ export function useConvertTokenToAnj(selectedToken) {
           twoHourExpiry,
           true,
           {
-            gasLimit: 650000,
+            gasLimit: 850000,
             value: amount,
           }
         )
@@ -351,7 +351,7 @@ export function useConvertTokenToAnj(selectedToken) {
         twoHourExpiry,
         activate,
         {
-          gasLimit: 650000,
+          gasLimit: 850000,
         }
       )
     },


### PR DESCRIPTION
See example logged failure: https://sentry.io/organizations/aragon-association/issues/1497279461/events/bc25c5ccd64a4225aa8194db1e68af0d/?project=1884499&statsPeriod=14d

Since the removal of these gas limits (#53), a number of similar errors have appeared where the user's wallet is not allowing them to send a transaction due to always an always failing transaction.

This adds back the hardcoded limits, to see if these errors will also stop.