### PR TITLE
Remove Fortmatic verification meta

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -24,7 +24,6 @@ jobs:
         SITE_ROOT: 'https://anj.aragon.org/'
         SENTRY_DSN: ${{ secrets.GH_PAGES_SENTRY_DSN }}
         PORTIS_DAPP_ID: ${{ secrets.GH_PAGES_PORTIS_DAPP_ID }}
-        FORTMATIC_SITE_VERIFICATION: ${{ secrets. GH_PAGES_FORTMATIC_SITE_VERIFICATION }}
         FORTMATIC_API_KEY: ${{ secrets.GH_PAGES_FORTMATIC_API_KEY }}
     - name: push to gh-pages
       uses: peaceiris/actions-gh-pages@v2

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 For rinkeby with Portis + Fortmatic:
 
 ```console
-FORTMATIC_SITE_VERIFICATION=<fortmatic_verification_key> FORTMATIC_API_KEY=<fortmatic_api_key> PORTIS_DAPP_ID=<portis_app_id> yarn deploy:rinkeby
+FORTMATIC_API_KEY=<fortmatic_api_key> PORTIS_DAPP_ID=<portis_app_id> yarn deploy:rinkeby
 ```
 
 For mainnet with Portis + Fortmatic:
 
 ```console
-FORTMATIC_SITE_VERIFICATION=<fortmatic_verification_key> FORTMATIC_API_KEY=<fortmatic_api_key> PORTIS_DAPP_ID=<portis_app_id> yarn deploy:mainnet
+FORTMATIC_API_KEY=<fortmatic_api_key> PORTIS_DAPP_ID=<portis_app_id> yarn deploy:mainnet
 ```

--- a/static.config.js
+++ b/static.config.js
@@ -56,8 +56,6 @@ export default {
     }
     render() {
       const { Html, Head, Body, children, renderMeta } = this.props
-      const fortmaticVerification =
-        process.env.FORTMATIC_SITE_VERIFICATION || null
       return (
         <Html>
           <Head>
@@ -66,12 +64,6 @@ export default {
               name="viewport"
               content="width=device-width, initial-scale=1"
             />
-            {fortmaticVerification && (
-              <meta
-                name="fortmatic-site-verification"
-                content={fortmaticVerification}
-              />
-            )}
             <title>Aragon Court</title>
             <link rel="icon" href="/favicon.png" />
             <link


### PR DESCRIPTION
Note: once merged, we should also remove the `GH_PAGES_FORTMATIC_SITE_VERIFICATION` secret on this repo.