### PR TITLE
Converter callout: Add uniswap link

### DIFF
--- a/src/components/converter/Callout.js
+++ b/src/components/converter/Callout.js
@@ -20,8 +20,14 @@ function Callout() {
         <p>
           Manage your ANJ balance from the{' '}
           <a className="pink" href="http://court.aragon.org/">
-            dashboard
+            dashboard.
           </a>
+          <br />
+          You can also{' '}
+          <a className="pink" href="https://uniswap.exchange/swap">
+            convert your ANJ
+          </a>{' '}
+          back to ANT and other tokens.
         </p>
       )}
     </CalloutContainer>


### PR DESCRIPTION
Adds a link to Uniswap so users can easily go convert their ANJ back into ANT and other tokens.