### PR TITLE
Stats: optimize query for active jurors

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -40,13 +40,14 @@ export function useAnJurors() {
               jurorsRegistryModules (first: 1) {
                 totalActive
               }
-               jurors(first: 1000, where: { activeBalance_gt: 0 }) {
-                activeBalance
+              jurors(first: 1000, where: { activeBalance_gt: 0 }) {
+                id
               }
             }
           `
         )
         if (
+          !response.jurors ||
           !response.jurorsRegistryModules ||
           response.jurorsRegistryModules.length === 0
         ) {


### PR DESCRIPTION
I _think_ getting ids (address) back will be slightly more optimized, as we otherwise get 18+ length strings back for each juror.