### PR TITLE
Converter: fix subscribe email error

### DIFF
--- a/components/converter/Form.js
+++ b/components/converter/Form.js
@@ -263,12 +263,13 @@ function FormSection() {
 
   const handleSubmit = async event => {
     event.preventDefault()
-
-    try {
-      await postEmail(email)
-    } catch (err) {
-      converterStatus.setStatus(CONVERTER_STATUSES.ERROR)
-      return
+    if (!emailExists) {
+      try {
+        await postEmail(email)
+      } catch (err) {
+        converterStatus.setStatus(CONVERTER_STATUSES.ERROR)
+        return
+      }
     }
 
     converterStatus.setStatus(


### PR DESCRIPTION
This issue was difficult to find in development, but the request for posting the email will fail if the email already exists, due to the request sending an empty email address.