### PR TITLE
Add correct legacy uniswap link

### DIFF
--- a/components/converter/Callout.js
+++ b/components/converter/Callout.js
@@ -15,7 +15,7 @@ function Callout() {
         . You can use{' '}
         <a
           className="pink"
-          href="https://uniswap.exchange/swap?inputCurrency=0xcD62b1C403fa761BAadFC74C525ce2B51780b184?outputCurrency=0x960b236A07cf122663c4303350609A66A7B288C0"
+          href="https://v1.uniswap.exchange/swap?inputCurrency=0xcD62b1C403fa761BAadFC74C525ce2B51780b184?outputCurrency=0x960b236A07cf122663c4303350609A66A7B288C0"
         >
           Uniswap
         </a>{' '}


### PR DESCRIPTION
This PR updates the anj.aragon.org uniswap link to use the legacy site.

**Note: Why?**

As Uniswap V2 was deployed to mainnet, now the "legacy" site is under v1.uniswap.exchange ; we're still using this one due to two reasons:

- We have not migrated the liquidity
- Querystrings do not seem to be working as well.

