### PR TITLE
Success: add email confirmation message if address is new

### DIFF
--- a/components/converter/Converter.js
+++ b/components/converter/Converter.js
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react'
 import styled from 'styled-components/macro'
 import { breakpoint } from 'lib/microsite-logic'
+import { useCheckEmailForAddress } from 'lib/utils'
 import Header from './Header'
 import ConverterContent from './ConverterContent'
 import ErrorScreen from './Error'
@@ -29,13 +30,14 @@ function Converter() {
 
 function ConverterIn() {
   const { status, setStatus } = useConverterStatus()
+  const emailExistsAtStart = useCheckEmailForAddress()
 
   const backToForm = useCallback(() => {
     setStatus(CONVERTER_STATUSES.FORM)
   }, [setStatus])
 
   if (status === CONVERTER_STATUSES.SUCCESS) {
-    return <SuccessScreen onDone={backToForm} />
+    return <SuccessScreen newJuror={!emailExistsAtStart} onDone={backToForm} />
   }
   if (status === CONVERTER_STATUSES.ERROR) {
     return <ErrorScreen onDone={backToForm} />
@@ -54,7 +56,7 @@ function ConverterIn() {
   ) {
     return <ProcessingScreen signing={status === CONVERTER_STATUSES.SIGNING} />
   }
-  return <ConverterContent />
+  return <ConverterContent emailExists={emailExistsAtStart} />
 }
 
 const ConverterSection = styled.div`

--- a/components/converter/ConverterContent.js
+++ b/components/converter/ConverterContent.js
@@ -10,17 +10,21 @@ import Providers from './Providers'
 
 const large = css => breakpoint('large', css)
 
-function ConverterContent() {
+function ConverterContent({ emailExists }) {
   const { account } = useWeb3Connect()
   return (
     <Content>
-      <div className="primary">{account ? <Form /> : <Providers />}</div>
+      <div className="primary">
+        {account ? <Form emailExists={emailExists} /> : <Providers />}
+      </div>
       <div className="secondary">
         <Balance />
         <Info />
         <Callout />
       </div>
-      <div className="primary-mobile">{account ? <Form /> : <Providers />}</div>
+      <div className="primary-mobile">
+        {account ? <Form emailExists={emailExists} /> : <Providers />}
+      </div>
     </Content>
   )
 }

--- a/components/converter/Form.js
+++ b/components/converter/Form.js
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components/macro'
 import * as Sentry from '@sentry/browser'
 import { OverlayTrigger, Tooltip } from 'react-bootstrap'
-import { bigNum, usePostEmail, useCheckEmailForAddress } from 'lib/utils'
+import { bigNum, usePostEmail } from 'lib/utils'
 import { breakpoint, GU } from 'lib/microsite-logic'
 import {
   useConvertTokenToAnj,
@@ -234,7 +234,7 @@ function useConvertInputs(otherSymbol) {
   }
 }
 
-function FormSection() {
+function FormSection({ emailExists }) {
   const [selectedOption, setSelectedOption] = useState(0)
   const tokenBalance = useTokenBalance(options[selectedOption])
   const ethBalance = useEthBalance()
@@ -252,7 +252,6 @@ function FormSection() {
 
   const convertTokenToAnj = useConvertTokenToAnj(options[selectedOption])
   const postEmail = usePostEmail()
-  const emailExists = useCheckEmailForAddress()
   const balanceAnj = useJurorRegistryAnjBalance()
   const selectedTokenDecimals = useTokenDecimals(options[selectedOption])
 

--- a/components/converter/Success.js
+++ b/components/converter/Success.js
@@ -6,7 +6,7 @@ import { useConverterStatus } from './converter-status'
 
 import successImg from './assets/success.svg'
 
-function SuccessSection({ onDone }) {
+function SuccessSection({ newJuror, onDone }) {
   const { lastAnjBought } = useConverterStatus()
   const decimals = useTokenDecimals('ANJ')
   return (
@@ -15,13 +15,20 @@ function SuccessSection({ onDone }) {
         <img src={successImg} alt="" />
         <p className="green">The transaction was successful</p>
         <p>
-          Welcome juror. You have successfully activated
+          {newJuror ? 'Welcome juror' : 'Welcome back, juror'}. You have
+          successfully activated
           {decimals > -1 && lastAnjBought.gte(0)
             ? ` the total amount of ${formatUnits(lastAnjBought, {
                 digits: decimals,
               })} ANJ.`
             : ` the requested ANJ amount.`}
         </p>
+        {newJuror && (
+          <p>
+            Please check your email to verify your subscription to Aragon Court
+            notifications.
+          </p>
+        )}
         <Button onClick={onDone}>Continue</Button>
       </div>
     </Success>
@@ -41,7 +48,6 @@ const Success = styled.div`
   }
   p {
     max-width: 410px;
-    margin: 0;
   }
   p.green {
     color: #7fdfa6;
@@ -53,7 +59,7 @@ const Button = styled.button`
   border: 1px solid #c7d1da;
   box-sizing: border-box;
   box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.05);
-  margin-top: 30px;
+  margin-top: 20px;
   border-radius: 4px;
   width: 227px;
   height: 52px;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -68,7 +68,9 @@ export function useCheckEmailForAddress() {
       }
     }
 
-    checkForEmail()
+    if (address) {
+      checkForEmail()
+    }
 
     return () => {
       cancelled = true


### PR DESCRIPTION
Lifts the email existing state up to the `Converter` parent component, so we can display different success states based on whether the juror is new or not.

This is a pretty quick fix to help notify jurors that they should be checking their emails after the conversion, as they will have to complete a verification step to complete the registration for notifications.

New jurors:
<img width="1203" alt="Screen Shot 2020-05-26 at 4 21 57 PM" src="https://user-images.githubusercontent.com/4166642/82912581-8e8bce00-9f6d-11ea-825c-6985f898afc1.png">

Existing jurors:

<img width="1196" alt="Screen Shot 2020-05-26 at 4 25 22 PM" src="https://user-images.githubusercontent.com/4166642/82912570-8b90dd80-9f6d-11ea-87a3-7f8df489c2df.png">