### PR TITLE
Emails: handle user opted-out state

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -45,8 +45,9 @@ export function useCheckEmailForAddress() {
         }
         const data = await response.json()
         if (!cancelled) {
-          const { emailExists } = data
-          setUserExists(emailExists)
+          const { addressVerified, emailExists } = data
+          // The user has either subscribed or opted out if they are in one of these two states
+          setUserExists(addressVerified || emailExists)
         }
       } catch (err) {
         console.error(


### PR DESCRIPTION
If the user has ever verified their address, we should also consider them to have interacted with the notification service and don't need to collect their email again.

This is primarily in the case of opting out of the notification service, where the user's email may not exist but they will have already verified their address.